### PR TITLE
fix(jest): transform vite meta env

### DIFF
--- a/typescript-react/babel.config.js
+++ b/typescript-react/babel.config.js
@@ -11,4 +11,5 @@ module.exports = {
     ['@babel/preset-react', { runtime: 'automatic' }],
     '@babel/preset-typescript',
   ],
+  plugins: ['babel-plugin-transform-vite-meta-env'],
 };

--- a/typescript-react/package-lock.json
+++ b/typescript-react/package-lock.json
@@ -32,6 +32,7 @@
         "@typescript-eslint/parser": "5.38.1",
         "@vitejs/plugin-react": "2.1.0",
         "@vitest/coverage-c8": "0.26.3",
+        "babel-plugin-transform-vite-meta-env": "1.0.3",
         "classnames": "^2.3.2",
         "eslint": "8.24.0",
         "eslint-config-prettier": "8.5.0",
@@ -4202,6 +4203,16 @@
       "integrity": "sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/babel-plugin-transform-vite-meta-env": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-vite-meta-env/-/babel-plugin-transform-vite-meta-env-1.0.3.tgz",
+      "integrity": "sha512-eyfuDEXrMu667TQpmctHeTlJrZA6jXYHyEJFjcM0yEa60LS/LXlOg2PBbMb8DVS+V9CnTj/j9itdlDVMcY2zEg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.13.9",
+        "@types/babel__core": "^7.1.12"
+      }
     },
     "node_modules/babel-preset-react-app": {
       "version": "10.0.1",
@@ -14414,6 +14425,16 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz",
       "integrity": "sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA==",
       "dev": true
+    },
+    "babel-plugin-transform-vite-meta-env": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-vite-meta-env/-/babel-plugin-transform-vite-meta-env-1.0.3.tgz",
+      "integrity": "sha512-eyfuDEXrMu667TQpmctHeTlJrZA6jXYHyEJFjcM0yEa60LS/LXlOg2PBbMb8DVS+V9CnTj/j9itdlDVMcY2zEg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.13.9",
+        "@types/babel__core": "^7.1.12"
+      }
     },
     "babel-preset-react-app": {
       "version": "10.0.1",

--- a/typescript-react/package.json
+++ b/typescript-react/package.json
@@ -40,6 +40,7 @@
     "@typescript-eslint/parser": "5.38.1",
     "@vitejs/plugin-react": "2.1.0",
     "@vitest/coverage-c8": "0.26.3",
+    "babel-plugin-transform-vite-meta-env": "1.0.3",
     "classnames": "^2.3.2",
     "eslint": "8.24.0",
     "eslint-config-prettier": "8.5.0",


### PR DESCRIPTION
**Front-end technical test**

Several candidates are having issues using Vite's environment variable in their unit tests (Jest can't interpret `import.meta.env`).

I've added a plugin that will allow Babel to transform Vite's environment variables into process.env so that Jest can interpret them.

[GitHub issue here](https://github.com/vitejs/vite/issues/1955)